### PR TITLE
:sparkles: Api pour exporter la config depuis le serveur

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ python manage.py calcul_resume_composition
 ```  
 Normalement le résumé clavier est recalculé automatiquement à chaque modification de la composition d'un orgue.
 
+Pour récupérer les configs depuis le site inventaire des orgues (Facteurs, types de jeux, types de claviers et )
+Téléchargez le fichier config.json depuis l'url du site : https://inventaire-des-orgues.fr/api/v1/config.json
+et lancer la commande suivante :
+
+```shell script
+python manage.py init_config --delete path/ver/config.json
+```
+
+l'option --delete permet de vider la base préalablement si nécessaire
+
 # Installation du moteur de recherche 
 
 Suivre la documentation pour installer meilisearch : 

--- a/orgues/api/views.py
+++ b/orgues/api/views.py
@@ -1,7 +1,10 @@
 from rest_framework import viewsets
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.renderers import JSONRenderer
 
 from orgues.api.serializers import OrgueSerializer
-from orgues.models import Orgue
+from orgues.models import Orgue, Facteur, Accessoire, TypeClavier, TypeJeu
 
 
 class OrgueViewSet(viewsets.ReadOnlyModelViewSet):
@@ -15,3 +18,18 @@ class OrgueViewSet(viewsets.ReadOnlyModelViewSet):
         if code_departement is not None:
             queryset = queryset.filter(code_departement=code_departement)
         return queryset.order_by('designation')
+
+class ConfigView(APIView):
+    renderer_classes = [JSONRenderer]
+
+    def get(self, request, format=None):
+        facteurs = Facteur.objects.all()
+        accessoires = Accessoire.objects.all()
+        typesClavier = TypeClavier.objects.all()
+        typesJeux = TypeJeu.objects.all()
+        return Response({
+            "facteurs": [facteur.nom for facteur in facteurs],
+            "types_claviers": [type.nom for type in typesClavier],
+            "types_jeux": [{"nom": type.nom, "hauteur": type.hauteur} for type in typesJeux],
+            "type_accessoire": [accessoire.nom for accessoire in accessoires]
+        })

--- a/orgues/management/commands/init_config.py
+++ b/orgues/management/commands/init_config.py
@@ -8,22 +8,40 @@ from orgues.models import TypeClavier, Facteur, TypeJeu, Accessoire
 
 class Command(BaseCommand):
     help = 'Population de la base de donnée avec les types de clavier et les jeux les plus courants'
+    def add_arguments(self, parser):
+        parser.add_argument('path', nargs='?', type=str,
+                        help='Chemin vers la config à importer')
+        parser.add_argument('--delete', help='Supprime les données existantes', action='store_true')
 
     def handle(self, *args, **options):
-
-        with open(os.path.join(settings.BASE_DIR, "orgues", "management", "commands", "config.json"),
+        path = os.path.join(settings.BASE_DIR, "orgues", "management", "commands", "config.json");
+        if options['path'] and os.path.exists(options['path']):
+            path = options['path']
+        if options['delete']:
+            print('Effacement de tous les objets de la base.')
+            TypeClavier.objects.all().delete()
+            TypeJeu.objects.all().delete()
+            Facteur.objects.all().delete()
+            Accessoire.objects.all().delete()
+        print('Import de la config '+path)
+        with open(path,
                   "r", encoding='utf-8') as f:
             data = json.load(f)
 
+        print('Import des types de claviers')
         for type_clavier in data["types_claviers"]:
             TypeClavier.objects.get_or_create(nom=type_clavier)
 
+        print('Import des types de jeux')
         for jeu in data["types_jeux"]:
-
             TypeJeu.objects.get_or_create(nom=jeu["nom"].strip(), hauteur=jeu["hauteur"].strip())
 
+        print('Import des facteurs')
         for facteur in data["facteurs"]:
             Facteur.objects.get_or_create(nom=facteur)
 
+        print('Import des types d\'accessoires')
         for accessoire in data["type_accessoire"]:
             Accessoire.objects.get_or_create(nom=accessoire)
+
+        print('Import terminé')

--- a/project/api_urls.py
+++ b/project/api_urls.py
@@ -11,7 +11,7 @@ RetrieveUpdateDestroyAPI views
 """
 from django.urls import include, path
 from rest_framework import routers
-from orgues.api.views import OrgueViewSet
+from orgues.api.views import OrgueViewSet, ConfigView
 
 
 router = routers.DefaultRouter()
@@ -19,4 +19,5 @@ router.register(r'orgues', OrgueViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('config.json', ConfigView.as_view())
 ]


### PR DESCRIPTION
Ajout d'une API pour pouvoir exporter la config du site depuis l'url https://inventaire-des-orgues.fr/api/v1/config.json

Modification du script init_config pour ajouter la possibilité de supprimer les données et de choisir le fichier à importer

Fix #384 