### PR TITLE
Amelioration image

### DIFF
--- a/orgues/templates/orgues/image_create.html
+++ b/orgues/templates/orgues/image_create.html
@@ -17,6 +17,7 @@
   <div class="form-group">
     <label for="">Précisez l'auteur des photos avant de commencer le chargement</label>
     <input type="text" class="form-control" id="id_credit">
+    <a class="nav-link" href="javascript:;" id="use-user-credit">Utiliser mon nom : {{ user }}</a>
   </div>
   <input type="file" id="filepond" class="d-none">
   <p class="text-right">
@@ -34,7 +35,10 @@
   <script src="https://unpkg.com/filepond/dist/filepond.min.js"></script>
 
   <script>
-    $("#id_credit").keyup(function () {
+    $("#use-user-credit").click(function() {
+      $("#id_credit").val("{{ user }}").trigger( "change" )
+    })
+    $("#id_credit").change(function () {
       if ($(this).val().length > 1) {
         $("#filepond").removeClass("d-none")
       } else {

--- a/orgues/templates/orgues/image_principale_form.html
+++ b/orgues/templates/orgues/image_principale_form.html
@@ -49,7 +49,7 @@
           processData: false,
           contentType: false,
           success() {
-            location.reload()
+            location.assign("{% url 'orgues:image-list' orgue.uuid %}")
           },
           error() {
             toastr.error("Oups, il y a eu une erreur");


### PR DESCRIPTION
Fix #451 

- Sur la page d'ajout d'image, un lien en dessous du champ texte, permet en cliquant dessus d'automatiquement remplir le champ avec son nom : 
![image](https://user-images.githubusercontent.com/841858/115260178-ce821380-a132-11eb-8ef3-9d95064d0459.png)
Puis en cliquant : 
![image](https://user-images.githubusercontent.com/841858/115260252-e22d7a00-a132-11eb-98e7-9b4d501e1424.png)

- Après avoir enregistré une vignette, retour directement sur la liste des images.