### PR TITLE
Modification des évènements MH

### DIFF
--- a/orgues/models.py
+++ b/orgues/models.py
@@ -607,7 +607,7 @@ class Evenement(models.Model):
 
     @property
     def is_locked(self):
-        return self.type not in ["classement_mh","inscription_mh"]
+        return self.type in ["classement_mh","inscription_mh"]
 
 
     def __str__(self):

--- a/orgues/templates/orgues/evenement_list.html
+++ b/orgues/templates/orgues/evenement_list.html
@@ -34,7 +34,7 @@
           <td style="width:140px" class="text-right">
       {% if perms.orgues.add_orgue or not evenement.is_locked %}
         <a href="{% url 'orgues:evenement-update' evenement.pk %}" class="btn btn-xs btn btn-outline">modifier</a>
-        <a href="{% url 'orgues:evenement-delete' evenement.pk %}" class="btn btn-xs  btn-danger btn-outline supprimer_evenement" data-pk="{{ evenement.pk }}">Supprimer</a>
+        <a href="{% url 'orgues:evenement-delete' evenement.pk %}" class="btn btn-xs btn-danger btn-outline supprimer_evenement" data-pk="{{ evenement.pk }}">Supprimer</a>
       {% endif %}
           </td>
         </tr>


### PR DESCRIPTION
@LucasBerbesson J'ai trouvé une autre coquille pour la modification des événements monuments historique, la condition était inversé, et donc maintenant on ne pouvait que modifier les événements monuments historique ...
![image](https://user-images.githubusercontent.com/841858/116525403-c4050e00-a8d8-11eb-8c8b-7cb2d2823fb9.png)
