### PR TITLE
Fix le problème de performance sur la carte

### DIFF
--- a/orgues/templates/orgues/carte.html
+++ b/orgues/templates/orgues/carte.html
@@ -394,6 +394,7 @@
 
     function afficher_orgue(orgues){
       //Affiche les orgues contenus dans la liste donnée en argument
+      markers = []
       for (var i = 0; i < orgues.length; i++) {
         var popup = '<p> <b>' + orgues[i].commune + '</b>' + '</br>' + orgues[i].edifice + '</br><a href="/detail/' + orgues[i].slug + '">Voir l\'orgue</a></p>';
         var ttip = '<b>' + orgues[i].commune + '</b>' + '</br>' + orgues[i].edifice;
@@ -405,8 +406,9 @@
           var marker = new L.Marker(latLng, {icon:nonmh_icon}).bindPopup(popup);
         }
         marker.bindTooltip(ttip);
-        markersCluster.addLayer(marker);
+        markers.push(marker);
         }
+        markersCluster.addLayers(markers);
         carte_orgues.addLayer(markersCluster);
     }
 


### PR DESCRIPTION
Actuellement, le moindre changement sur les filtres de la carte mettent beaucoup de temps à s'afficher.
C'est dût que fait que l'on fait un addLayer dans la boucle pour afficher les orgues ce qui engendre un recalcule de tous les groupes d'orgues sur la carte à chaque ajout d'un orgue.
Ici, on ne n'ajoute les markers qu'une fois à la fin de la boucle.