### PR TITLE
Fix recherche facteur carte

### DIFF
--- a/orgues/templates/orgues/carte.html
+++ b/orgues/templates/orgues/carte.html
@@ -4,7 +4,7 @@
 {% block head_extra %}
   <link rel="stylesheet" href="{% static 'plugins/leaflet/leaflet.css' %}">
   <link rel="stylesheet" href="{% static 'plugins/leafletcluster/MarkerCluster.Default.css' %}">
-  <link rel="stylesheet" href="{% static 'plugins/slider/jquery-ui.css' %}">  
+  <link rel="stylesheet" href="{% static 'plugins/slider/jquery-ui.css' %}">
   <link rel="stylesheet" href="{% static 'plugins/leafletgeosearch/geosearch.css' %}">
   <link rel="stylesheet" href="{% static 'plugins/leafletlocate/L.Control.Locate.min.css' %}">
 {% endblock %}
@@ -16,7 +16,7 @@
   </div>
   <div id="div_filtre">
     <b class="titre_filtre">Filtrer les orgues</b>
-    
+
     <form id="filtre_formulaire" class="carte_formulaire" action="" >
       <div class="div_carte">
         <label><b>Uniquement les orgues classés monuments historiques : </b><input type="checkbox" name="mh" id="mh"></label>
@@ -177,7 +177,7 @@
 
     $.getJSON("{% url 'orgues:orgue-list-js' %}", function (orgues) {
       //Affiche les orgues à l'ouverture de la page.
-      liste_orgues = orgues;  
+      liste_orgues = orgues;
       afficher_orgue(orgues);
     });
 
@@ -191,7 +191,7 @@
       return function(organ){
         //Sélection des orgues classés
         if (filter.mh && organ.references_palissy === null) {
-          return false;        
+          return false;
         }
 
         //Sélection des orgues par le nombre de jeux
@@ -203,7 +203,7 @@
         if (organ.resume_composition !== null) {
           var resume = organ.resume_composition.split(" ")[1];
           if (! filter.composition_filter.includes(resume)) {
-            return false;          
+            return false;
           }
         }
         else{
@@ -211,11 +211,11 @@
             return false;
           }
         }
-      
+
         //Sélection des orgues par leur état
         if (organ.etat === null) {
           if (! filter.etat_NR) {
-            return false;          
+            return false;
           }
         }
         else{
@@ -231,7 +231,7 @@
           }
         }
         return true;
-      }     
+      }
     }
 
     function organ_builder_event_satisfied(facteur_pk, construction, organ_facteurs) {
@@ -250,7 +250,7 @@
           }
           else{
             result = true;
-          }          
+          }
         }
       });
       return result;
@@ -261,7 +261,7 @@
       const claviers = $('input[name="clavier"]:checked').map((_, item) => $(item).val()).get();
       return $("input[name='Pedalier']").is(':checked') ? claviers.concat(claviers.map(item => item + "/P")) : claviers ;
     }
-    
+
     function update_filter() {
       // Met à jour la liste des orgues à afficher
       markersCluster.clearLayers();
@@ -294,8 +294,8 @@
     });
 
     function update_jeu_range(){
-      $( "#jeu-range" ).html( 
-        "Nombre de jeux : " + $( "#slider-range" ).slider( "values", 0 ) + " - " +  $( "#slider-range" ).slider( "values", 1 ) 
+      $( "#jeu-range" ).html(
+        "Nombre de jeux : " + $( "#slider-range" ).slider( "values", 0 ) + " - " +  $( "#slider-range" ).slider( "values", 1 )
       );
     }
 
@@ -318,7 +318,7 @@
       $("input[name='etat']").prop('checked', true);
       $("input[name='etat_NR']").prop('checked', true);
       $("#construction").prop('checked', false);
-      $("#facteur_pk").empty();  
+      $("#facteur_pk").empty();
       $( "#slider-range" ).slider( "values", [0, 130]);
     })
 
@@ -334,6 +334,7 @@
           return query;
         }
       },
+      allowClear: true,
       placeholder: {
         id: '-1',
         text: 'Tous les facteurs'
@@ -361,6 +362,7 @@
           return query;
         }
       },
+      allowClear: true,
       escapeMarkup: function (markup) {
         return markup;
       },

--- a/orgues/views.py
+++ b/orgues/views.py
@@ -175,7 +175,6 @@ class FacteurListJSlonlat(ListView):
     documentation : https://select2.org/data-sources/ajax
     """
     model = Facteur
-    permission_required = 'orgues.view_facteur'
     paginate_by = 30
 
     def get_queryset(self):
@@ -712,7 +711,6 @@ class FacteurListJS(ListView):
     documentation : https://select2.org/data-sources/ajax
     """
     model = Facteur
-    permission_required = 'orgues.view_facteur'
     paginate_by = 30
 
     def get_queryset(self):

--- a/orgues/views.py
+++ b/orgues/views.py
@@ -16,7 +16,7 @@ from django.forms import modelformset_factory
 from django.http import JsonResponse, Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy, reverse
-from django.views.generic import DetailView, TemplateView
+from django.views.generic import DetailView, TemplateView, ListView
 from django.views.generic.base import View
 
 import orgues.forms as orgue_forms
@@ -138,7 +138,7 @@ class OrgueCarte(TemplateView):
 
 class OrgueListJS(View):
     """
-    Cette vue est requêtée par Leaflet lors de l'affichage de la carte de France dans "orgues/carte.html". Elle 
+    Cette vue est requêtée par Leaflet lors de l'affichage de la carte de France dans "orgues/carte.html". Elle
     renvoie sous format json tous les orgues disposant d'une latitude et d'une longitude.
     """
     def get(self, request, *args, **kwargs):
@@ -169,7 +169,7 @@ class FacteurLonLatLeaflet(View):
         return JsonResponse(list(data), safe=False)
 
 
-class FacteurListJSlonlat(FabListView):
+class FacteurListJSlonlat(ListView):
     """
     Liste dynamique utilisée pour filtrer les facteurs d'orgue dans les menus déroulants select2. Utilisée pour le filtre de la carte.
     documentation : https://select2.org/data-sources/ajax
@@ -269,7 +269,7 @@ class OrgueHistJSDep(View):
             references_palissy["PasCla"] = references_palissy.get(None, 0)
             del references_palissy[None]
         return JsonResponse(references_palissy, safe=False)
-    
+
 class Avancement(View):
     """
     JSON contenant le taux d'avancement moyen selon le niveau de zoom
@@ -286,13 +286,13 @@ class Avancement(View):
         # Aggrégation par départements
         departements = df.groupby('departement').agg({'completion': ['count', 'mean']}).reset_index().round()
         departements.columns = ["Département", "Orgues", "Avancement"]
-        
+
         # Aggrégation par régions
         regions = df.groupby('region').agg({'completion': ['count', 'mean']}).reset_index().round()
         regions.columns = ["Region", "Orgues", "Avancement"]
         # Réglage du bug sur Mayotte
         regions.loc[[0], "Region"] = "Mayotte"
-        
+
         # Calcul de la moyenne selon le niveau de zoom
         if entite in regions["Region"].values:
             moy["total"] = (regions.loc[regions["Region"] == entite, ["Region", "Avancement"]]).iloc[0,1]
@@ -424,7 +424,7 @@ class OrgueCreate(FabCreateView, ContributionOrgueMixin):
     def get_success_url(self):
         success_url = reverse('orgues:orgue-detail', args=(self.object.slug,))
         return self.request.POST.get("next", success_url)
-         
+
 class OrgueUpdateMixin(FabUpdateView, ContributionOrgueMixin):
     """
     Mixin de modification d'un orgue qui permet de systématiquement:
@@ -706,7 +706,7 @@ class TypeJeuListJS(FabView):
         }
 
 
-class FacteurListJS(FabListView):
+class FacteurListJS(ListView):
     """
     Liste dynamique utilisée pour filtrer les facteurs d'orgue dans les menus déroulants select2.
     documentation : https://select2.org/data-sources/ajax


### PR DESCRIPTION
Fix #538 

Les recherches de facteur dans la carte utilisait une route qui demandait d'avoir les droits facteur.view pour faire la recherche.
Or on avait pas ces droits là lorsque l'on visite le site sans être connecté.
J'ai simplement supprimer la vérification de droits sur ces URLs.

J'ai également ajouter la possibilité de désélectionner un facteurs dans la liste (une croix pour clear le champ).