### PR TITLE
réduit taille liste des facteurs

### DIFF
--- a/orgues/templates/orgues/orgue_list.html
+++ b/orgues/templates/orgues/orgue_list.html
@@ -72,6 +72,7 @@
                       <span v-if="orgue.resume_composition">, ((orgue.resume_composition))</span>
                     </p>
                   {% endspaceless %}
+                  <div class="line-clamp-3">
                   {% spaceless %}
                     <p class="my-0">
                       <b>Localisation : </b>
@@ -96,6 +97,7 @@
                     : ((orgue.completion))%
                   </div>
                 {% endif %}
+                </div>
               </div>
             </div>
           </div>

--- a/static/static_dirs/polo/css/custom.css
+++ b/static/static_dirs/polo/css/custom.css
@@ -159,6 +159,13 @@ span.puce-etat {
 
 }
 
+#orgue-list .line-clamp-3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;  
+    overflow: hidden;
+}
+
 /* CLAVIERS */
 
 #claviers {


### PR DESCRIPTION
Correction de l'affichage des vignettes si il y a plein de facteurs dans la liste de résultat.
![image](https://user-images.githubusercontent.com/841858/131972637-169cc361-c99a-4317-bbc3-9f2a07f9c297.png)

fix #569 
