### PR TITLE
Bouton, pour changer le tri des recherches

### DIFF
--- a/orgues/api/serializers.py
+++ b/orgues/api/serializers.py
@@ -89,6 +89,7 @@ class OrgueResumeSerializer(serializers.ModelSerializer):
     facet_facteurs = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     jeux = serializers.SerializerMethodField()
+    construction = serializers.SerializerMethodField()
 
     class Meta:
         model = Orgue
@@ -111,7 +112,8 @@ class OrgueResumeSerializer(serializers.ModelSerializer):
             "longitude", 
             "jeux",
             "claviers_count",
-            "has_pedalier",
+            "jeux_count",
+            "construction",
             "resume_composition_clavier",
         ]
 
@@ -137,8 +139,16 @@ class OrgueResumeSerializer(serializers.ModelSerializer):
         facteurs = set()
         evenements = Evenement.objects.filter(orgue=obj, facteurs__isnull=False).prefetch_related('facteurs').order_by('annee')
         for evenement in evenements:
-            facteurs.update(evenement.facteurs.values_list('nom', flat=True))
+            if evenement.type in ['construction', 'reconstruction']:
+                facteurs.update(evenement.facteurs.values_list('nom', flat=True))
         return list(facteurs)
+
+    def get_construction(self, obj):
+        evenements = Evenement.objects.filter(orgue=obj).order_by('-annee')
+        for evenement in evenements:
+            if evenement.type in ['construction', 'reconstruction']:
+                return evenement.annee
+        return ''
 
 
 class OrgueCarteSerializer(serializers.ModelSerializer):

--- a/orgues/management/commands/build_meilisearch_index.py
+++ b/orgues/management/commands/build_meilisearch_index.py
@@ -18,14 +18,13 @@ class Command(BaseCommand):
             index = client.get_index(uid='orgues')
         except:
             index = client.create_index(uid='orgues')
-
         index.update_searchable_attributes([
             'commune',
-            'ancienne_commune',
             'edifice',
-            'region',
             'facteurs',
             'departement',
+            'region',
+            'ancienne_commune',
             'placeholder',
             'latitude',
             'longitude'
@@ -56,6 +55,7 @@ class Command(BaseCommand):
             'url',
             'latitude',
             'longitude',
+            'construction',
         ])
 
         index.update_ranking_rules([
@@ -63,9 +63,15 @@ class Command(BaseCommand):
             'words',
             'proximity',
             'attribute',
-            'wordsPosition',
+            'sort',
+            'completion:desc',
             'exactness',
-            'desc(completion)',
+        ])
+        index.update_sortable_attributes([
+            'commune',
+            'completion',
+            'jeux_count',
+            'construction',
         ])
         orgues = OrgueResumeSerializer(Orgue.objects.all(), many=True).data
         index.delete_all_documents()

--- a/orgues/templates/orgues/orgue_list.html
+++ b/orgues/templates/orgues/orgue_list.html
@@ -56,7 +56,24 @@
           </div>
         </div>
         <div class="col-xl-8" v-cloak>
-          <p class="text-muted text-center" v-if="!loading">((hits)) orgue<span v-if="hits>1">s</span></p>
+          <div class="text-muted" v-if="!loading">
+            <div class="dropdown float-right" v-if="orgues.length != 0">
+              <button class="btn btn-link dropdown-toggle" type="button" id="filterMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Trier
+              </button>
+              <div class="dropdown-menu dropdown-menu-right" aria-labelledby="filterMenuButton">
+                <a class="dropdown-item" href="#" @click.prevent="changeSort('completion:desc')" :class="{ active: sort == 'completion:desc' }">+ Complétés</a>
+                <a class="dropdown-item" href="#" @click.prevent="changeSort('pertinence')" :class="{ active: sort == 'pertinence' }">Pertinence</a>
+                <a class="dropdown-item" href="#" @click.prevent="changeSort('commune:asc')" :class="{ active: sort == 'commune:asc' }">Commune A-Z</a>
+                <a class="dropdown-item" href="#" @click.prevent="changeSort('commune:desc')" :class="{ active: sort == 'commune:desc' }">Commune Z-A</a>
+                <a class="dropdown-item" href="#" @click.prevent="changeSort('construction:asc')" :class="{ active: sort == 'construction:asc' }">Ancien - Récent</a>
+                <a class="dropdown-item" href="#" @click.prevent="changeSort('construction:desc')" :class="{ active: sort == 'construction:desc' }">Récent - Ancient</a>
+                <a class="dropdown-item" href="#" @click.prevent="changeSort('jeux_count:desc')" :class="{ active: sort == 'jeux_count:desc' }">+ de jeux</a>
+              </div>
+            </div>
+            <p class="text-center" v-if="!loading">((hits)) orgue<span v-if="hits>1">s</span></p>
+          </div>
+          <div class="clearfix"></div>
           <div class="card" v-if="loading">
             <div class="card-body">
               <div class="d-flex align-items-center">
@@ -151,6 +168,7 @@
         debouncedInput: '{{ query|default_if_none:''|escapejs }}',
         hits: 0,
         page: {% if page %}{{ page}}{% else %}1{% endif %},
+        sort: 'completion:desc',
         pages: 0,
         loading: false,
         open: false,
@@ -204,6 +222,10 @@
           this.page = 1
           this.fetchData()
         },
+        changeSort: function(sort) {
+          this.sort = sort
+          this.fetchData()
+        },
         unselectFacet: function(facet, value) {
           var index = this.filter[facet].indexOf(value);
           if (index !== -1) {
@@ -220,6 +242,7 @@
           var query = self.debouncedInput
           var departement = self.departement
           var page = self.page
+          var sort = self.sort
           this.loading = true
           this.requete_page = this.page;
 
@@ -229,6 +252,9 @@
           }
           if (query) {
             pageUrl += '&query=' + query
+          }
+          if (sort) {
+            pageUrl += '&sort=' + sort
           }
           let filters = {}
           if (self.filter) {
@@ -247,6 +273,7 @@
               pageUrl: pageUrl,
               page: page,
               departement: departement,
+              sort: sort,
               ...filters,
             },
             error: function (resp) {

--- a/orgues/views.py
+++ b/orgues/views.py
@@ -136,6 +136,9 @@ class OrgueSearch(View):
             options['filter'] = filter
         if not query:
             query = None
+        sort = request.POST.get('sort')
+        if sort and sort != 'pertinence':
+            options['sort'] = [sort]
         results = index.search(query, options)
         results['pages'] = 1 + results['nbHits'] // OrgueSearch.paginate_by
         if 'facetsDistribution' in results:


### PR DESCRIPTION
fix #593 

![image](https://user-images.githubusercontent.com/841858/135619062-3a60373d-a371-4c4a-9fba-d5024e29d329.png)

Ajoute la possibilité de trier les résultats.
- + Complétés
- Pertinence
- Commune A-Z
- Commune Z-A
- Ancien - Récent
- Récent - Ancient
- + de jeux
Par défaut, la recherche est trié par les fiches les plus complétés.

![image](https://user-images.githubusercontent.com/841858/135619122-606dc8a3-4776-4fa4-b4f7-1a0d1348a50d.png)


