### PR TITLE
Disparu

### DIFF
--- a/orgues/management/commands/build_meilisearch_index.py
+++ b/orgues/management/commands/build_meilisearch_index.py
@@ -74,6 +74,7 @@ class Command(BaseCommand):
             'longitude',
             'construction',
             'modified_date',
+            'etat',
         ])
 
         index.update_ranking_rules([

--- a/orgues/models.py
+++ b/orgues/models.py
@@ -61,7 +61,8 @@ class Orgue(models.Model):
         ('bon', "Bon : jouable, défauts mineurs"),
         ('altere', "Altéré : difficilement jouable"),
         ('degrade', "Dégradé ou en ruine : injouable"),
-        ('restauration', "En restauration (ou projet initié)")
+        ('restauration', "En restauration (ou projet initié)"),
+        ('disparu', 'Disparu')
     )
 
     CHOIX_QUALIFICATION_PALISSY = (

--- a/orgues/templates/orgues/base_edition.html
+++ b/orgues/templates/orgues/base_edition.html
@@ -23,7 +23,10 @@
 
 
           <h2 class="mb-0">
-            {{ orgue.edifice|capfirst }} <br>
+            {{ orgue.edifice|capfirst }} 
+            {% if orgue.etat == "disparu" %}
+              (Orgue disparu) 
+            {% endif %} <br>
           </h2>
           <h4 class="text-muted">
             {{ orgue.commune }}{% if orgue.ancienne_commune %} ({{ orgue.ancienne_commune }}){% endif %}, {{ orgue.departement }}

--- a/orgues/templates/orgues/carte_popup.html
+++ b/orgues/templates/orgues/carte_popup.html
@@ -22,6 +22,7 @@
             {% if orgue.designation %}{{ orgue.designation }} {% else %} Orgue {% endif %}
             {% if orgue.emplacement %}, {{ orgue.emplacement }} {% endif %}
             {% if orgue.resume_composition %}, {{ orgue.resume_composition }} {% endif %}
+            {% if orgue.etat == "disparu" %}, Orgue disparu {% endif %}
           </div>
           <div><b>Localisation: </b>{{ orgue.edifice }}, {{ orgue.commune }}, {{ orgue.departement }} ({{ orgue.region }})</div>
           <div><b>Facteurs:</b> {% for evenement in orgue.evenements.all %}{% for facteur in evenement.facteurs.all %}{{ facteur.nom }}, {% endfor %}{% endfor %}</div>

--- a/orgues/templates/orgues/orgue_detail.html
+++ b/orgues/templates/orgues/orgue_detail.html
@@ -35,7 +35,10 @@
       <div class="row justify-content-center text-md-left">
         <div class="col-lg-9 my-4 text-center text-md-left">
           <h2 class="mb-0">
-            {{ orgue.edifice|capfirst }} <br>
+            {{ orgue.edifice|capfirst }}  
+              {% if orgue.etat == "disparu" %}
+                  (Orgue disparu)
+              {% endif %} <br>
           </h2>
 
           {% spaceless %}

--- a/orgues/templates/orgues/orgue_list.html
+++ b/orgues/templates/orgues/orgue_list.html
@@ -99,6 +99,7 @@
                       <span v-if="!orgue.designation">Orgue</span>
                       <span v-if="orgue.emplacement">, ((orgue.emplacement))</span>
                       <span v-if="orgue.resume_composition">, ((orgue.resume_composition))</span>
+                      <span v-if="orgue.etat === 'Disparu'">, Orgue disparu</span>
                     </p>
                   {% endspaceless %}
                   <div class="line-clamp-3">

--- a/orgues/views.py
+++ b/orgues/views.py
@@ -1456,7 +1456,7 @@ class Stats(View):
         return dict((k, self.normalize(v)) for k, v in res.items())
 
     def normalize(self, data):
-        total = data['count'] or 0
+        total = data['count'] - data['disparu'] or 0
         return {
             'total': total,
             'mh': data['mh'] or 0,
@@ -1466,4 +1466,5 @@ class Stats(View):
             'degrade': round(100 * ((data['degrade'] or 0) + (data['restauration'] or 0)) / total, 0),
             'inconnu': round(
                 100 * (total - (data['altere'] or 0) - (data['bon'] or 0) - (data['tres_bon'] or 0) - (data['degrade'] or 0) - (data['restauration'] or 0)) / total, 0),
+            'disparu' : data['disparu'],
         }

--- a/templates/accueil.html
+++ b/templates/accueil.html
@@ -351,12 +351,16 @@
           <h3 id="selected-region">((selected))</h3>
           <p class="text-bold" id="nb-etat-total">
             <span class="puce-etat bg-primary">((data.total))</span>
-            <span>Nombre d'orgues recensés</span>
+            <span>Nombre d'orgues existants recensés</span>
           </p>
           <!-- Puce contenant le nombre d'orgues inscrits ou classés -->
 	        <p id="nbInsCla">
             <span class="puce-etat " style="background-color:#C31A38;">((data.mh))</span>
             <span>Orgues inscrits ou classés</span>
+          </p>
+          <p id="nbInsCla">
+            <span class="puce-etat " style="background-color:#eba510;">((data.disparu))</span>
+            <span>Nombre d'orgues disparus</span>
           </p>
 	        <!-- Puce contenant le taux d'avancement moyen -->
           <br>


### PR DESCRIPTION
Proposition pour les fiches des orgues disparus. Ce serait dommage de ne pas en garder une trace.

Ajout dans les possibilités des états des orgues de l'état "Orgue disparu"
Affichage de "Orgue disparu" dans l'en-tête des fiches des orgues, dans la liste de recherche des orgues et dans la carte.
Mise à jour des statistiques sur la page d'accueil