### PR TITLE
Ajout d'une page présentant tous les événements concernant un facteur

### DIFF
--- a/orgues/templates/orgues/facteurs_list.html
+++ b/orgues/templates/orgues/facteurs_list.html
@@ -1,0 +1,145 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+
+<script src="https://cdn.jsdelivr.net/npm/vue@2.6.0"></script>
+<script src="https://unpkg.com/vue-select@latest"></script>
+<link rel="stylesheet" href="https://unpkg.com/vue-select@latest/dist/vue-select.css">
+
+
+<div class="container" id="app">
+  <section id="orgue-list">
+    <div class="row">
+      <div class="col-xl-4">
+        <div class="card">
+          <div class="card-body" id="search-form">
+            <div class="form-group">
+              <label for="">Facteur</label>
+                <v-select v-model="facteur" :options="facteurs" :reduce="facteur => facteur.pk" label="nom" v-model="facteur"/>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-xl-8" v-cloak>
+        <div class="clearfix"></div>
+        <div class="card" v-if="loading">
+          <div class="card-body">
+            <div class="d-flex align-items-center">
+              <strong>Chargement...</strong>
+              <div class="spinner-border ml-auto" role="status" aria-hidden="true"></div>
+            </div>
+          </div>
+        </div>
+        <div v-for="(value, key) in evenements">
+          <h4 class="card-title mb-0">
+            (( key ))
+          </h4>
+        
+          <div v-for="evenement in value" class="card shadow-sm vignette mb-lg-4 mb-sm-5 orgue-card" @click="select(evenement.orgue)">
+            <div class="row no-gutters">
+              <div class="col-lg-4 la_vignette" style="background: #868e96;">
+                <span v-if="evenement.orgue.etat === 'Disparu'">
+                  <img class="card-img-top" :src="evenement.orgue.vignette" alt="Photo orgue" style="filter: grayscale(1);">
+                </span>
+                <span v-else>
+                  <img class="card-img-top" :src="evenement.orgue.vignette" alt="Photo orgue" style="">
+                </span>
+              </div>
+              <div class="col-lg-8">
+                <div class="card-body py-md-3">
+                  <h4 class="card-title mb-0">
+                    <span v-html="evenement.type"></span> : 
+                    <span v-html="evenement.orgue.edifice"></span>
+                    | <span v-html="evenement.orgue.commune"></span>, <span v-html="evenement.orgue.departement"></span>
+                  </h4>
+                  {% spaceless %}
+                    <p class=" my-0">
+                      <span v-html="evenement.orgue.designation"></span>
+                      <span v-if="!evenement.orgue.designation">Orgue</span>
+                      <span v-if="evenement.orgue.emplacement">, ((evenement.orgue.emplacement))</span>
+                      <span v-if="evenement.orgue.resume_composition">, ((evenement.orgue.resume_composition))</span>
+                      <span v-if="evenement.orgue.etat === 'Disparu'">, Orgue disparu</span>
+                    </p>
+                  {% endspaceless %}
+                  <div class="line-clamp-3">
+                  {% spaceless %}
+                    <p class="my-0">
+                      <span v-html="evenement.orgue.ancienne_commune" v-if="evenement.orgue.ancienne_commune"></span>
+                      <span v-if="evenement.orgue.ancienne_commune"></span>
+                    </p>
+                  {% endspaceless %}
+                </div>
+
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+
+  
+{% endblock %}
+{% block js_extra %}
+
+{{ facteurs|json_script:"facteurs" }}
+
+<script>
+
+Vue.component('v-select', VueSelect.VueSelect);
+var facteurs = JSON.parse(document.getElementById('facteurs').textContent);
+
+var app = new Vue({
+  el: '#app',
+  data: {
+    facteurs:facteurs,
+    facteur:'{{ facteur|default_if_none:'' }}',
+    evenements:[],
+    loading:false,
+  },
+  watch: {
+        facteur: function () {
+          this.evenements = [];
+          if (this.facteur ) {
+            this.fetchData();
+          }       
+        },
+      },
+
+  methods: {
+    fetchData: function(){
+      facteur_pk = this.facteur;
+      this.loading=true;
+      var self = this;
+      
+       $.ajax({
+          type: "GET",
+          url: "{% url 'orgues:evenement-facteur-js' %}",
+          data: {
+            csrfmiddlewaretoken: '{{ csrf_token }}',
+            facteur: facteur_pk,
+          },
+          error: function (resp) {
+            self.loading = false;
+            toastr.error(resp.responseJSON.message);
+          },
+          success: function (results) {
+            self.loading = false;
+            self.evenements = results;            
+          },
+      });
+    },
+
+    select: function (orgue) {
+          window.location.href = orgue.url;
+    },
+  
+  },
+  delimiters: ["((", "))"]
+
+})
+</script>
+  
+{% endblock %}

--- a/orgues/urls.py
+++ b/orgues/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('evenement/edition/<int:pk>/', v.EvenementUpdate.as_view(), name='evenement-update'),
     path('evenement/creation/<uuid:orgue_uuid>/', v.EvenementCreate.as_view(), name='evenement-create'),
     path('evenement/suppression/<int:pk>/', v.EvenementDelete.as_view(), name='evenement-delete'),
+    path('js/evenement/', v.EvenementfacteurJS.as_view(), name='evenement-facteur-js'),
     path('provenance/creation/', v.ProvenanceCreateJS.as_view(), name='provenance-create-js'),
 
     # claviers
@@ -45,6 +46,7 @@ urlpatterns = [
     path('js/facteurs/creation/', v.FacteurCreateJS.as_view(), name='facteur-create-js'),
     path('js/facteurs/lonlat/', v.FacteurListJSlonlat.as_view(), name='facteur-list-js-lonlat'),
     path('js/facteurs/lonlatLeaflet/', v.FacteurLonLatLeaflet.as_view(), name='facteur-js-lonlat'),
+    path('facteurs/', v.FacteursList.as_view(), name='facteurs-list'),
 
     # types jeux
     path('types_jeux/creation/', v.TypeJeuCreateJS.as_view(), name='typejeu-create-js'),

--- a/templates/base.html
+++ b/templates/base.html
@@ -120,6 +120,9 @@
             <a href="{% url 'orgues:orgue-list' %}">Les orgues</a>
           </li>
           <li>
+            <a href="{% url 'orgues:facteurs-list' %}">Les facteurs</a>
+          </li>
+          <li>
             <a href="{% url 'lexique' %}">Lexique</a>
           </li>
           <li>


### PR DESCRIPTION
On choisit un facteur d'orgue et on affiche dans l'ordre chronologique tous les orgues qui ont un événement le concernant.

En revanche, il va falloir mettre un peu d'ordre dans les doublons de noms de facteurs (mais le script existe déjà il me semble). Et de temps en temps, pour un même facteur, il y a des événements qui s'étalent sur 150 ans (Eugène Abbey par exemple)...

![image](https://github.com/inventaire-des-orgues/portail/assets/79277114/ae64e0d0-35c9-4c60-8d62-718d4cd0afb3)
![image](https://github.com/inventaire-des-orgues/portail/assets/79277114/cfff000e-0810-45e3-b0d8-4b7ad9932143)
![image](https://github.com/inventaire-des-orgues/portail/assets/79277114/2832100f-648b-4e94-8f0e-97d8d38a4019)
