### PR TITLE
Filtres

### DIFF
--- a/orgues/api/serializers.py
+++ b/orgues/api/serializers.py
@@ -119,7 +119,8 @@ class OrgueResumeSerializer(serializers.ModelSerializer):
             "jeux_count",
             "construction",
             "resume_composition_clavier",
-            "modified_date"
+            "modified_date",
+            "proprietaire"
         ]
 
     def get_etat(self, obj):

--- a/orgues/management/commands/build_meilisearch_index.py
+++ b/orgues/management/commands/build_meilisearch_index.py
@@ -51,7 +51,8 @@ class Command(BaseCommand):
             'facet_facteurs',
             'jeux',
             'jeux_count',
-            'monument_historique'
+            'monument_historique',
+            'proprietaire'
         ])
 
         index.update_displayed_attributes([

--- a/orgues/models.py
+++ b/orgues/models.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
+from django.db.models import Q
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from django.urls import reverse
@@ -401,7 +402,7 @@ class Orgue(models.Model):
         """
         Nombre de jeux de l'instrument
         """
-        return Jeu.objects.filter(clavier__orgue=self).count()
+        return Jeu.objects.filter(Q(clavier__orgue=self)&~Q(type__nom="Tirasse permanente")).count()
 
     @property
     def claviers_count(self):

--- a/orgues/templates/orgues/orgue_list.html
+++ b/orgues/templates/orgues/orgue_list.html
@@ -24,7 +24,7 @@
                   <div :class="{'facet-open': facetOpen[facet.field], 'facet-list': facet.items.length > 6 }" class="facet-list">
                     <ul>
                       <li v-for="selected in filter[facet.field]" @click="unselectFacet(facet.field, selected)" class="facets selected">((selected))</li>
-                      <li v-for="item in facet.items" v-if="!filter[facet.field] || !filter[facet.field].includes(item.name)" @click="selectFacet(facet.field, item.name)" class="facets">((item.name)) [((item.count))]</li>
+                      <li v-for="item in facet.items" v-if="!filter[facet.field] || !filter[facet.field].includes(item.name)" @click="selectFacet(facet.field, item.name)" class="facets">((item.name))</li>
                     </ul>
                     <a @click="openFacet(facet.field)" v-if="facet.items.length > 6">Voir ((facetOpen[facet.field] ? "moins" : "plus"))</a>
                   </div>
@@ -172,6 +172,7 @@
         sort: 'completion:desc',
         pages: 0,
         loading: false,
+        init: true,
         open: false,
         orgues: [],
         facets: {},
@@ -186,14 +187,15 @@
       },
       watch: {
         debouncedInput: function () {
-          this.page = 1
+          this.page = 1          
           this.filter = {}
           this.fetchData()
         },
         departement: function () {
           this.page = 1
-          this.filter = {}
-          this.fetchData()
+          this.filter = {};
+          this.init = true;        
+          this.fetchData();
         },
       },
       computed: {
@@ -213,7 +215,7 @@
         openFacet: function(field) {
           this.$set(this.facetOpen, field, !this.facetOpen[field])
         },
-        selectFacet: function(facet, value) {
+        selectFacet: function(facet, value) {          
           if (this.filter[facet]) {
             if (!this.filter[facet].includes(value))  
               this.filter[facet].push(value)
@@ -256,7 +258,7 @@
           }
           if (sort) {
             pageUrl += '&sort=' + sort
-          }
+          }          
           let filters = {}
           if (self.filter) {
             for (const [key, values] of Object.entries(self.filter)) {
@@ -275,6 +277,7 @@
               page: page,
               departement: departement,
               sort: sort,
+              init: self.init,
               ...filters,
             },
             error: function (resp) {
@@ -291,6 +294,7 @@
                 self.facetOpen = {}
               }
               self.filter = results.filter
+              self.init = false; 
               if (scrolltop) window.scrollTo(0, 0);
               window.history.pushState('', '', pageUrl);
             },

--- a/orgues/templates/orgues/orgue_list.html
+++ b/orgues/templates/orgues/orgue_list.html
@@ -215,12 +215,12 @@
         },
         selectFacet: function(facet, value) {
           if (this.filter[facet]) {
-            if (!this.filter[facet].includes(value))
+            if (!this.filter[facet].includes(value))  
               this.filter[facet].push(value)
           }
           else
             this.filter[facet] = [value]
-          this.page = 1
+            this.page = 1
           this.fetchData()
         },
         changeSort: function(sort) {
@@ -261,7 +261,7 @@
           if (self.filter) {
             for (const [key, values] of Object.entries(self.filter)) {
                 pageUrl += '&filter_' + key + '=' + values.join(',');
-                filters['filter_' + key] = values.join(',');
+                filters['filter_' + key] = values.join(';;');
             }
           }
 

--- a/orgues/views.py
+++ b/orgues/views.py
@@ -123,7 +123,7 @@ class OrgueSearch(View):
         except:
             return JsonResponse({'message': 'Le moteur de recherche est mal configuré'}, status=500)
 
-        facets = ['departement', 'region', 'resume_composition_clavier', 'facet_facteurs', 'jeux', 'proprietaire']
+        facets = ['departement', 'region', 'resume_composition_clavier', 'facet_facteurs', 'jeux', 'proprietaire', 'etat']
         options = {'attributesToHighlight': ['*'], 'hitsPerPage': OrgueSearch.paginate_by, 'page': int(page)}
 
         filter = []
@@ -131,7 +131,7 @@ class OrgueSearch(View):
         for facet in facets:
             arg = request.POST.get('filter_' + facet)
             if arg:
-                values = arg.split(',')
+                values = arg.split(';;')
                 filter.append(['{}="{}"'.format(facet, value) for value in values])
                 filterResult[facet] = values
         if not filterResult and page == '1' and (query or departement or region):
@@ -156,7 +156,7 @@ class OrgueSearch(View):
 
     @staticmethod
     def convertFacets(facetDistribution):
-        labels = {'departement': 'Département', 'region': 'Régions', 'resume_composition_clavier': 'Nombres de claviers', 'facet_facteurs': 'Facteurs', 'jeux': 'Jeux', 'proprietaire': 'Propriétaire'}
+        labels = {'departement': 'Département', 'region': 'Régions', 'resume_composition_clavier': 'Nombres de claviers', 'facet_facteurs': 'Facteurs', 'jeux': 'Jeux', 'proprietaire': 'Propriétaire', 'etat':'Etat'}
         return [{'label': labels[name], 'field': name,
                  'items': sorted([{'name': item, 'count': count} for item, count in values.items()], key=lambda k: k['count'], reverse=True)} for name, values in
                 facetDistribution.items()]

--- a/orgues/views.py
+++ b/orgues/views.py
@@ -126,6 +126,18 @@ class OrgueSearch(View):
         facets = ['departement', 'region', 'resume_composition_clavier', 'facet_facteurs', 'jeux', 'proprietaire', 'etat']
         options = {'attributesToHighlight': ['*'], 'hitsPerPage': OrgueSearch.paginate_by, 'page': int(page)}
 
+        # Première requête qui permet de récupérer toutes les possibilités dans chaque facet
+        options["facets"] = facets
+        filter_init = []
+        if departement:
+            filter_init.append('departement="{}"'.format(departement))
+        if region:
+            filter_init.append('region="{}"'.format(region))
+        if len(filter_init) > 0:
+            options['filter'] = filter_init
+        results_init = index.search(query, options)
+
+        # Deuxième requête pour récupérer les orgues correspondant aux filtres
         filter = []
         filterResult = {}
         for facet in facets:
@@ -134,8 +146,11 @@ class OrgueSearch(View):
                 values = arg.split(';;')
                 filter.append(['{}="{}"'.format(facet, value) for value in values])
                 filterResult[facet] = values
-        if not filterResult and page == '1' and (query or departement or region):
-            options['facets'] = facets
+        init = request.POST.get('init')
+        
+        # Si c'est l'initialisation de la page ou d'un département, alors par défaut, on n'affiche pas les orgues disparus
+        if init=="true":
+            filter.append(['etat="{}"'.format(value[1]) for value in Orgue.CHOIX_ETAT if value[1] != "Disparu"])
         if departement:
             filter.append('departement="{}"'.format(departement))
         if region:
@@ -149,8 +164,13 @@ class OrgueSearch(View):
             options['sort'] = [sort]
         results = index.search(query, options)
         if 'facetDistribution' in results:
-            results['facets'] = OrgueSearch.convertFacets(results['facetDistribution'])
+            results['facets'] = OrgueSearch.convertFacets(results_init['facetDistribution'])
             del results['facetDistribution']
+        
+        # Si c'est l'initialisation de la page ou d'un département, 
+        # alors par défaut, on ne surligne pas "Disparu" dans la colonne des filtres 
+        if init=="true":
+            filterResult['etat'] = ['Très bon, tout à fait jouable', 'Bon : jouable, défauts mineurs', 'Altéré : difficilement jouable', 'Dégradé ou en ruine : injouable', 'En restauration (ou projet initié)']
         results['filter'] = filterResult
         return results
 
@@ -158,7 +178,7 @@ class OrgueSearch(View):
     def convertFacets(facetDistribution):
         labels = {'departement': 'Département', 'region': 'Régions', 'resume_composition_clavier': 'Nombres de claviers', 'facet_facteurs': 'Facteurs', 'jeux': 'Jeux', 'proprietaire': 'Propriétaire', 'etat':'Etat'}
         return [{'label': labels[name], 'field': name,
-                 'items': sorted([{'name': item, 'count': count} for item, count in values.items()], key=lambda k: k['count'], reverse=True)} for name, values in
+                 'items': sorted([{'name': item, 'count': count} for item, count in values.items()], key=lambda k: k['name'])} for name, values in
                 facetDistribution.items()]
 
 

--- a/orgues/views.py
+++ b/orgues/views.py
@@ -123,7 +123,7 @@ class OrgueSearch(View):
         except:
             return JsonResponse({'message': 'Le moteur de recherche est mal configuré'}, status=500)
 
-        facets = ['departement', 'region', 'resume_composition_clavier', 'facet_facteurs', 'jeux']
+        facets = ['departement', 'region', 'resume_composition_clavier', 'facet_facteurs', 'jeux', 'proprietaire']
         options = {'attributesToHighlight': ['*'], 'hitsPerPage': OrgueSearch.paginate_by, 'page': int(page)}
 
         filter = []
@@ -156,7 +156,7 @@ class OrgueSearch(View):
 
     @staticmethod
     def convertFacets(facetDistribution):
-        labels = {'departement': 'Département', 'region': 'Régions', 'resume_composition_clavier': 'Nombres de claviers', 'facet_facteurs': 'Facteurs', 'jeux': 'Jeux'}
+        labels = {'departement': 'Département', 'region': 'Régions', 'resume_composition_clavier': 'Nombres de claviers', 'facet_facteurs': 'Facteurs', 'jeux': 'Jeux', 'proprietaire': 'Propriétaire'}
         return [{'label': labels[name], 'field': name,
                  'items': sorted([{'name': item, 'count': count} for item, count in values.items()], key=lambda k: k['count'], reverse=True)} for name, values in
                 facetDistribution.items()]


### PR DESCRIPTION
* Ajout d'un filtre sur le propriétaire
* Ajout d'un filtre sur l'état d'un instrument
* Par défaut, les instruments disparus ne sont pas affichés
* Les filtres sont affichés dès que l'on ouvre la page "Les orgues" (y avait-il une raison de ne les afficher que lorsque l'on cherchait un département ?)
* Suppression du nombre d'instruments en fonction de chaque filtre car ne fonctionnait pas dès lors que l'on faisait une intersection de plusieurs filtres. Cela me semble compliqué de faire les calculs qui fonctionnent, peut-être pour plus tard
* La tirasse permanente n'est plus comptée comme un jeu